### PR TITLE
Swift wta_nib bugfix

### DIFF
--- a/WTAHelpers/WTANibLoading/UIView+WTANibLoading.m
+++ b/WTAHelpers/WTANibLoading/UIView+WTANibLoading.m
@@ -17,7 +17,20 @@
 
 + (UINib *)wta_nib
 {
-    return [self wta_nibNamed:[[NSStringFromClass([self class]) componentsSeparatedByString:@"."] lastObject]];
+    NSString* className = NSStringFromClass([self class]);
+    NSString *file = [[NSBundle mainBundle] pathForResource:className ofType:@"nib"];
+    if (file) {
+        return [self wta_nibNamed:className];
+    }
+    
+    className = [[className componentsSeparatedByString:@"."] lastObject];
+    file = [[NSBundle mainBundle] pathForResource:className ofType:@"nib"];
+    
+    if (file) {
+        return [self wta_nibNamed:className];
+    }
+    
+    return nil;
 }
 
 + (instancetype)wta_loadInstanceWithNib:(UINib *)nib

--- a/WTAHelpers/WTANibLoading/UIView+WTANibLoading.m
+++ b/WTAHelpers/WTANibLoading/UIView+WTANibLoading.m
@@ -17,7 +17,7 @@
 
 + (UINib *)wta_nib
 {
-    return [self wta_nibNamed:NSStringFromClass([self class])];
+    return [self wta_nibNamed:[[NSStringFromClass([self class]) componentsSeparatedByString:@"."] lastObject]];
 }
 
 + (instancetype)wta_loadInstanceWithNib:(UINib *)nib


### PR DESCRIPTION
Swift classes return `<ModuleName>.<ClassName>` as their classname. This pulls correct piece in both original and swift cases