### PR TITLE
WTAAutoLayoutHelpers bug fixes.

### DIFF
--- a/WTAHelpers/WTAAutoLayoutHelpers/NSLayoutConstraint+WTAAutoLayoutHelpers.m
+++ b/WTAHelpers/WTAAutoLayoutHelpers/NSLayoutConstraint+WTAAutoLayoutHelpers.m
@@ -55,7 +55,7 @@
 {
     NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:withView
                                                                   attribute:NSLayoutAttributeTop
-                                                                  relatedBy:NSLayoutRelationEqual
+                                                                  relatedBy:relation
                                                                      toItem:toView
                                                                   attribute:NSLayoutAttributeTop
                                                                  multiplier:1.0

--- a/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.m
+++ b/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.m
@@ -223,6 +223,12 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
 {
     NSLayoutConstraint *verticalConstraint = [self wta_addVerticallyCenterConstraintToSuperviewOffset:offset.y];
     NSLayoutConstraint *horizontalConstraint = [self wta_addHorizontallyCenterConstraintToSuperviewOffset:offset.x];
+    
+    [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
+    
+    [self.superview addConstraint:verticalConstraint];
+    [self.superview addConstraint:horizontalConstraint];
+    
     return @[verticalConstraint, horizontalConstraint];
 }
 
@@ -272,7 +278,13 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
 {
     NSLayoutConstraint *widthConstraint = [self wta_addWidthConstraint:size.width];
     NSLayoutConstraint *heightConstraint = [self wta_addHeightConstraint:size.height];
-    return @[widthConstraint, heightConstraint];
+
+    [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
+    
+    [self addConstraint:heightConstraint];
+    [self addConstraint:widthConstraint];
+    
+    return @[heightConstraint, widthConstraint];
 }
 
 - (NSLayoutConstraint *)wta_addHeightConstraint:(CGFloat)height


### PR DESCRIPTION
UIView Category
  * ***addCenteringConstraintsToSuperviewOffsets:*** wasn't adding constraints to the superview.
  * ***addSizeConstraints:*** wasn't adding constraints to the view.

NSLayoutConstraint Category
  * ***topConstraintWithView:toView:offset:relation:*** wasn't using relation.