### PR TITLE
Swift 2.0, Xcode 7 Audit for Nullability + First Swift-specific Helper

### DIFF
--- a/WTAHelpers.podspec
+++ b/WTAHelpers.podspec
@@ -42,4 +42,8 @@ Pod::Spec.new do |s|
     ss.source_files = 'WTAHelpers/WTADeviceHelpers/*.{h,m}'
     ss.frameworks = 'SystemConfiguration', 'AVFoundation'
   end
+
+  s.subspec 'WTASwiftHelpers' do |ss|
+    ss.source_files = 'WTAHelpers/WTASwiftHelpers/*.swift'
+  end
 end

--- a/WTAHelpers.xcodeproj/project.pbxproj
+++ b/WTAHelpers.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		878CD8DB18BBA59D00C4DCF4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 879CB61A18B3FDF8002DCDAA /* UIKit.framework */; };
 		BDCB7B9619D45ED30077A547 /* UIColor+WTAColorHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = BDCB7B9519D45ED30077A547 /* UIColor+WTAColorHelpers.m */; };
 		BDCB7B9A19D4636D0077A547 /* UIDevice+WTADeviceHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = BDCB7B9919D4636D0077A547 /* UIDevice+WTADeviceHelpers.m */; };
+		E1B0F0481B84C9CC0023AF4D /* UIControl+ActionBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B0F0471B84C9CC0023AF4D /* UIControl+ActionBinding.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -76,6 +77,8 @@
 		BDCB7B9519D45ED30077A547 /* UIColor+WTAColorHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+WTAColorHelpers.m"; sourceTree = "<group>"; };
 		BDCB7B9819D4636D0077A547 /* UIDevice+WTADeviceHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIDevice+WTADeviceHelpers.h"; sourceTree = "<group>"; };
 		BDCB7B9919D4636D0077A547 /* UIDevice+WTADeviceHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIDevice+WTADeviceHelpers.m"; sourceTree = "<group>"; };
+		E1B0F0461B84C9CC0023AF4D /* WTAHelpersDemo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WTAHelpersDemo-Bridging-Header.h"; sourceTree = "<group>"; };
+		E1B0F0471B84C9CC0023AF4D /* UIControl+ActionBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIControl+ActionBinding.swift"; path = "WTAHelpers/WTASwiftHelpers/UIControl+ActionBinding.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +211,7 @@
 				873F3C2F18BD21CE0052E0DC /* WTANibLoading */,
 				873F3C3418BD21CE0052E0DC /* WTAReusableIdentifier */,
 				878CD87C18BB9CCB00C4DCF4 /* WTAFrameHelpers */,
+				E1B0F0451B84C9A10023AF4D /* WTASwiftHelpers */,
 				874A4D7818BE771D009FEC4E /* WTAHelpers.h */,
 			);
 			name = Source;
@@ -279,6 +283,16 @@
 			path = WTADeviceHelpers;
 			sourceTree = "<group>";
 		};
+		E1B0F0451B84C9A10023AF4D /* WTASwiftHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				E1B0F0471B84C9CC0023AF4D /* UIControl+ActionBinding.swift */,
+				E1B0F0461B84C9CC0023AF4D /* WTAHelpersDemo-Bridging-Header.h */,
+			);
+			name = WTASwiftHelpers;
+			path = WTAFrameHelpers;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -306,6 +320,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = WTA;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = "WillowTree Apps, Inc.";
 			};
@@ -349,6 +364,7 @@
 				878284D618BE432A005D1AEB /* WTADemoAutoLayoutHelperViewController.m in Sources */,
 				873F3C4618BD24FA0052E0DC /* NSLayoutConstraint+WTAAutoLayoutHelpers.m in Sources */,
 				BDCB7B9619D45ED30077A547 /* UIColor+WTAColorHelpers.m in Sources */,
+				E1B0F0481B84C9CC0023AF4D /* UIControl+ActionBinding.swift in Sources */,
 				BDCB7B9A19D4636D0077A547 /* UIDevice+WTADeviceHelpers.m in Sources */,
 				878284DA18BE432A005D1AEB /* WTANavigationController.m in Sources */,
 				878284D818BE432A005D1AEB /* WTAFrameHelpersCell.m in Sources */,
@@ -384,6 +400,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WTAHelpersDemo/WTAHelpersDemo-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -391,7 +408,10 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "WTAHelpersDemo/WTAHelpersDemo-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WTAHelpers/WTAFrameHelpers/WTAHelpersDemo-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -401,10 +421,13 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WTAHelpersDemo/WTAHelpersDemo-Prefix.pch";
 				INFOPLIST_FILE = "WTAHelpersDemo/WTAHelpersDemo-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WTAHelpers/WTAFrameHelpers/WTAHelpersDemo-Bridging-Header.h";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/WTAHelpers/WTAAutoLayoutHelpers/NSLayoutConstraint+WTAAutoLayoutHelpers.h
+++ b/WTAHelpers/WTAAutoLayoutHelpers/NSLayoutConstraint+WTAAutoLayoutHelpers.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSLayoutConstraint (WTAAutoLayoutHelpers)
 
@@ -55,3 +56,4 @@
 + (NSLayoutConstraint *)wta_equalHeightConstraintWithView:(UIView*)view toView:(UIView*)toView offset:(CGFloat)offset;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTAAutoLayoutHelpers/NSLayoutConstraint+WTAAutoLayoutHelpers.h
+++ b/WTAHelpers/WTAAutoLayoutHelpers/NSLayoutConstraint+WTAAutoLayoutHelpers.h
@@ -51,4 +51,7 @@
 + (NSLayoutConstraint *)wta_heightConstraintWithView:(UIView *)view height:(CGFloat)height relation:(NSLayoutRelation)relation;
 + (NSLayoutConstraint *)wta_widthConstraintWithView:(UIView *)view width:(CGFloat)width relation:(NSLayoutRelation)relation;
 
++ (NSLayoutConstraint *)wta_equalWidthConstraintWithView:(UIView*)view toView:(UIView*)toView offset:(CGFloat)offset;
++ (NSLayoutConstraint *)wta_equalHeightConstraintWithView:(UIView*)view toView:(UIView*)toView offset:(CGFloat)offset;
+
 @end

--- a/WTAHelpers/WTAAutoLayoutHelpers/NSLayoutConstraint+WTAAutoLayoutHelpers.m
+++ b/WTAHelpers/WTAAutoLayoutHelpers/NSLayoutConstraint+WTAAutoLayoutHelpers.m
@@ -179,4 +179,29 @@
     return constraint;
 }
 
++ (NSLayoutConstraint *)wta_equalWidthConstraintWithView:(UIView *)view toView:(UIView *)toView offset:(CGFloat)offset
+{
+    NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:view
+                                                                  attribute:NSLayoutAttributeWidth
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:toView
+                                                                  attribute:NSLayoutAttributeWidth
+                                                                 multiplier:1.0
+                                                                   constant:offset];
+    
+    return constraint;
+}
+
++ (NSLayoutConstraint *)wta_equalHeightConstraintWithView:(UIView *)view toView:(UIView *)toView offset:(CGFloat)offset
+{
+    NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:view
+                                                                  attribute:NSLayoutAttributeHeight
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:toView
+                                                                  attribute:NSLayoutAttributeHeight
+                                                                 multiplier:1.0
+                                                                   constant:offset];
+    
+    return constraint;
+}
 @end

--- a/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.h
+++ b/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+NS_ASSUME_NONNULL_BEGIN
 
 @interface UIView (WTAAutoLayoutHelpers)
 
@@ -19,7 +20,7 @@
  
  @return The newly created view.
  */
-+ (id)wta_autolayoutView;
++ (__kindof UIView*)wta_autolayoutView;
 
 ///------------------------------------------------------------------------
 /// @name Automatically Setting TranslatesAutoresizingMasksIntoConstraints
@@ -46,7 +47,7 @@
  @param inset for the constraints.
  @return array of constraints
  */
-- (NSArray *)wta_addEdgeConstraintsToSuperview:(UIEdgeInsets)inset;
+- (NSArray<NSLayoutConstraint*> *)wta_addEdgeConstraintsToSuperview:(UIEdgeInsets)inset;
 
 /**
  Creates a leading constraint to the current view with offset. The constraint is added the view's superview
@@ -190,8 +191,8 @@
  @return array of the created constraints.
  @param offset from the center.
  */
-- (NSArray *)wta_addCenteringConstraintToSuperview;
-- (NSArray *)wta_addCenteringConstraintToSuperviewOffset:(CGPoint)offset;
+- (NSArray<NSLayoutConstraint*> *)wta_addCenteringConstraintToSuperview;
+- (NSArray<NSLayoutConstraint*> *)wta_addCenteringConstraintToSuperviewOffset:(CGPoint)offset;
 
 /**
  Creates a constraint to vertically center the current view. The constraint is added to the view's superview.
@@ -242,7 +243,7 @@
  @param relation of the offset.
  @return array of size constraints.
  */
-- (NSArray *)wta_addSizeConstraints:(CGSize)size;
+- (NSArray<NSLayoutConstraint*> *)wta_addSizeConstraints:(CGSize)size;
 
 /**
  Adds a constraint to set the height of the current view.
@@ -264,4 +265,13 @@
 - (NSLayoutConstraint *)wta_addWidthConstraint:(CGFloat)width;
 - (NSLayoutConstraint *)wta_addWidthConstraint:(CGFloat)width relation:(NSLayoutRelation)relation;
 
+/**
+ Adds constraints to set the size of the view equal to the size of another
+ 
+ @param toView the view that the current view will be set equal in size to
+ @param offset to shrink or grow the view by a fixed amount in both width and height relative to toView
+ @return array of size constraints
+ */
+- (NSArray<NSLayoutConstraint*> *)wta_addEqualSizeConstraintsToView:(UIView*)toView offset:(CGFloat)offset;
 @end
+NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.h
+++ b/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.h
@@ -273,5 +273,23 @@ NS_ASSUME_NONNULL_BEGIN
  @return array of size constraints
  */
 - (NSArray<NSLayoutConstraint*> *)wta_addEqualSizeConstraintsToView:(UIView*)toView offset:(CGFloat)offset;
+
+/**
+ Adds a constraint to set the width of the view equal to the width of another
+ 
+ @param toView the view that the current view will be set equal in width to
+ @param offset to shrink or grow the view by a fixed amount in width relative to toView
+ @return the newly activated constraint
+ */
+- (NSLayoutConstraint*)wta_addEqualWidthConstraintToView:(UIView*)toView offset:(CGFloat)offset;
+
+/**
+ Adds a constraint to set the height of the view equal to the height of another
+ 
+ @param toView the view that the current view will be set equal in height to
+ @param offset to shrink or grow the view by a fixed amount in height relative to toView
+ @return the newly activated constraint
+ */
+- (NSLayoutConstraint *)wta_addEqualHeightConstraintToView:(UIView*)toView offset:(CGFloat)offset;
 @end
 NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.m
+++ b/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.m
@@ -319,4 +319,25 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
     return constraints;
 }
 
+- (nonnull NSLayoutConstraint*)wta_addEqualWidthConstraintToView:(nonnull UIView *)toView offset:(CGFloat)offset
+{
+    [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
+    
+    NSLayoutConstraint* constraint = [NSLayoutConstraint wta_equalWidthConstraintWithView:self toView:toView offset:offset];
+    
+    [NSLayoutConstraint activateConstraints:@[constraint]];
+    
+    return constraint;
+}
+
+- (nonnull NSLayoutConstraint*)wta_addEqualHeightConstraintToView:(nonnull UIView *)toView offset:(CGFloat)offset
+{
+    [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
+    
+    NSLayoutConstraint* constraint = [NSLayoutConstraint wta_equalHeightConstraintWithView:self toView:toView offset:offset];
+    
+    [NSLayoutConstraint activateConstraints:@[constraint]];
+    
+    return constraint;
+}
 @end

--- a/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.m
+++ b/WTAHelpers/WTAAutoLayoutHelpers/UIView+WTAAutoLayoutHelpers.m
@@ -15,7 +15,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
 
 #pragma mark - Convenience Constructors
 
-+ (id)wta_autolayoutView;
++ (__kindof UIView*)wta_autolayoutView;
 {
     id view = [self new];
     [view setTranslatesAutoresizingMaskIntoConstraints:NO];
@@ -44,7 +44,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
 
 #pragma mark - Edge Constraints to Superview
 
-- (NSArray *)wta_addEdgeConstraintsToSuperview:(UIEdgeInsets)inset
+- (NSArray<NSLayoutConstraint*> *)wta_addEdgeConstraintsToSuperview:(UIEdgeInsets)inset
 {
     NSLayoutConstraint *topConstraint = [self wta_addTopConstraintToSuperviewOffset:inset.top];
     NSLayoutConstraint *leadingConstraint = [self wta_addLeadingConstraintToSuperviewOffset:inset.left];
@@ -105,7 +105,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
 {
     NSLayoutConstraint *constraint = [NSLayoutConstraint wta_leadingConstraintWithView:self toView:toView offset:offset relation:relation];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -118,7 +118,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
 {
     NSLayoutConstraint *constraint = [NSLayoutConstraint wta_trailingConstraintWithView:self toView:toView offset:offset relation:relation];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -131,7 +131,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
 {
     NSLayoutConstraint *constraint = [NSLayoutConstraint wta_topConstraintWithView:self toView:toView offset:offset relation:relation];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -143,7 +143,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
 - (NSLayoutConstraint *)wta_addBottomConstraintToView:(UIView *)toView offset:(CGFloat)offset relation:(NSLayoutRelation)relation
 {
     NSLayoutConstraint *constraint = [NSLayoutConstraint wta_bottomConstraintWithView:self toView:toView offset:offset relation:relation];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -161,7 +161,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
                                                                                               separation:separation
                                                                                                 relation:relation];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -177,7 +177,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
                                                                                               separation:separation
                                                                                                 relation:relation];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -192,7 +192,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
                                                                                    bottomView:view
                                                                                    separation:separation
                                                                                      relation:relation];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -208,18 +208,18 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
                                                                                    separation:separation
                                                                                      relation:relation];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
 #pragma mark - Centering Constraints
 
-- (NSArray *)wta_addCenteringConstraintToSuperview
+- (NSArray<NSLayoutConstraint*> *)wta_addCenteringConstraintToSuperview
 {
     return [self wta_addCenteringConstraintToSuperviewOffset:CGPointZero];
 }
 
-- (NSArray *)wta_addCenteringConstraintToSuperviewOffset:(CGPoint)offset
+- (NSArray<NSLayoutConstraint*> *)wta_addCenteringConstraintToSuperviewOffset:(CGPoint)offset
 {
     NSLayoutConstraint *verticalConstraint = [self wta_addVerticallyCenterConstraintToSuperviewOffset:offset.y];
     NSLayoutConstraint *horizontalConstraint = [self wta_addHorizontallyCenterConstraintToSuperviewOffset:offset.x];
@@ -252,7 +252,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
                                                                                            toView:toView
                                                                                            offset:offset];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -262,13 +262,13 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
                                                                                          toView:toView
                                                                                          offset:offset];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [[self superview] addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
 #pragma mark - Size Constraints
 
-- (NSArray *)wta_addSizeConstraints:(CGSize)size
+- (NSArray<NSLayoutConstraint*> *)wta_addSizeConstraints:(CGSize)size
 {
     NSLayoutConstraint *widthConstraint = [self wta_addWidthConstraint:size.width];
     NSLayoutConstraint *heightConstraint = [self wta_addHeightConstraint:size.height];
@@ -286,7 +286,7 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
                                                                                height:height
                                                                              relation:relation];
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [self addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
 }
 
@@ -302,8 +302,21 @@ static BOOL __wta_automaticallySetAutoTranslatesAutoresizingMasksToOff = NO;
                                                                             relation:relation];
     
     [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
-    [self addConstraint:constraint];
+    [NSLayoutConstraint activateConstraints:@[constraint]];
     return constraint;
+}
+
+- (NSArray<NSLayoutConstraint*> *)wta_addEqualSizeConstraintsToView:(UIView*)toView offset:(CGFloat)offset
+{
+    [self wta_setTranslatesAutoresizingMasksIntoConstraintsIfNeeded];
+    
+    NSArray<NSLayoutConstraint*>* constraints = @[[NSLayoutConstraint wta_equalWidthConstraintWithView:self toView:toView offset:offset],
+                                                  [NSLayoutConstraint wta_equalHeightConstraintWithView:self
+                                                                                                 toView:toView
+                                                                                                 offset:offset]];
+    [NSLayoutConstraint activateConstraints:constraints];
+    
+    return constraints;
 }
 
 @end

--- a/WTAHelpers/WTAColorHelpers/UIColor+WTAColorHelpers.h
+++ b/WTAHelpers/WTAColorHelpers/UIColor+WTAColorHelpers.h
@@ -25,38 +25,40 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIColor (WTAColorHelpers)
 
-+ (instancetype)wta_colorNamed:(NSString *)colorName;
++ (nullable instancetype)wta_colorNamed:(NSString *)colorName;
 
-+ (void)wta_setColor:(UIColor *)color forName:(NSString *)colorName;
++ (void)wta_setColor:(nullable UIColor *)color forName:(NSString *)colorName;
 + (BOOL)wta_setColors:(NSDictionary *)colors;
 + (BOOL)wta_setColorsWithContentsOfFile:(NSString *)path;
 
-+ (instancetype)wta_colorWithString:(NSString *)colorString;
-+ (instancetype)wta_colorWithHexString:(NSString *)hexString; // #f2f2f2, 0xcbcbcbff
-+ (instancetype)wta_colorWithHexRGB:(NSUInteger)RGB;
-+ (instancetype)wta_colorWithHexRGBA:(NSUInteger)RGBA;
-+ (instancetype)wta_colorWithRGBAString:(NSString *)RGBAString; // rgba(0.0, 0.0, 0.0, 0.0)
-+ (instancetype)wta_colorWith8BitRGBAColorComponents:(const CGFloat *)components;
-+ (instancetype)wta_colorWith8BitRed:(CGFloat)red
++ (nullable instancetype)wta_colorWithString:(NSString *)colorString;
++ (nullable instancetype)wta_colorWithHexString:(NSString *)hexString; // #f2f2f2, 0xcbcbcbff
++ (nullable instancetype)wta_colorWithHexRGB:(NSUInteger)RGB;
++ (nullable instancetype)wta_colorWithHexRGBA:(NSUInteger)RGBA;
++ (nullable instancetype)wta_colorWithRGBAString:(NSString *)RGBAString; // rgba(0.0, 0.0, 0.0, 0.0)
++ (nullable instancetype)wta_colorWith8BitRGBAColorComponents:(const CGFloat *)components;
++ (nullable instancetype)wta_colorWith8BitRed:(CGFloat)red
                            green:(CGFloat)green
                             blue:(CGFloat)blue
                            alpha:(CGFloat)alpha;
 
-- (NSString *)wta_hexStringValue;
-- (NSString *)wta_RGBAStringValue;
+- (nullable NSString *)wta_hexStringValue;
+- (nullable NSString *)wta_RGBAStringValue;
 
 @end
 
 @interface NSString (WTAColorHelpers)
 
-- (NSString *)wta_hexColorString;
-- (NSArray *)wta_RGBColorComponents;
+- (nullable NSString *)wta_hexColorString;
+- (nullable NSArray<NSString*> *)wta_RGBColorComponents;
 
 @end
 
-CG_INLINE CGColorRef WTACGColorCreateWith8BitRGBA(CGFloat r, CGFloat g, CGFloat b, CGFloat a)
+CG_INLINE __nullable CGColorRef WTACGColorCreateWith8BitRGBA(CGFloat r, CGFloat g, CGFloat b, CGFloat a)
 {
     const CGFloat components[] = {(r / 255.0), (g / 255.0), (b / 255.0), a};
     CGColorSpaceRef spaceRef = CGColorSpaceCreateDeviceRGB();
@@ -65,7 +67,7 @@ CG_INLINE CGColorRef WTACGColorCreateWith8BitRGBA(CGFloat r, CGFloat g, CGFloat 
     return colorRef;
 }
 
-CG_INLINE CGColorRef WTACGColorCreateWithHexRGBA(u_int32_t RBGA)
+CG_INLINE __nullable CGColorRef WTACGColorCreateWithHexRGBA(u_int32_t RBGA)
 {
     return WTACGColorCreateWith8BitRGBA(((RBGA & 0xFF000000) >> 24),
                                      ((RBGA & 0xFF0000) >> 16),
@@ -73,7 +75,7 @@ CG_INLINE CGColorRef WTACGColorCreateWithHexRGBA(u_int32_t RBGA)
                                      (RBGA & 0xFF));
 }
 
-CG_INLINE CGColorRef WTACGColorCreateWithHexString(NSString *hexString)
+CG_INLINE __nullable CGColorRef WTACGColorCreateWithHexString(NSString * __nullable hexString)
 {
     hexString = [hexString wta_hexColorString];
     if (hexString != nil)
@@ -85,7 +87,7 @@ CG_INLINE CGColorRef WTACGColorCreateWithHexString(NSString *hexString)
     return NULL;
 }
 
-CG_INLINE CGColorRef WTACGColorCreateWithRGBAString(NSString *RGBAString)
+CG_INLINE __nullable CGColorRef WTACGColorCreateWithRGBAString(NSString * __nonnull RGBAString)
 {
     NSArray *components = [RGBAString wta_RGBColorComponents];
     if ([components count] == 4)
@@ -98,3 +100,5 @@ CG_INLINE CGColorRef WTACGColorCreateWithRGBAString(NSString *RGBAString)
     
     return NULL;
 }
+
+NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTAColorHelpers/UIColor+WTAColorHelpers.m
+++ b/WTAHelpers/WTAColorHelpers/UIColor+WTAColorHelpers.m
@@ -27,7 +27,7 @@
 
 @implementation UIColor (WTAColorHelpers)
 
-+ (NSMutableDictionary *)wta_colors
++ ( NSMutableDictionary * _Nonnull )wta_colors
 {
     static NSMutableDictionary *_colorDictionary = nil;
     static dispatch_once_t onceToken;
@@ -37,12 +37,12 @@
     return _colorDictionary;
 }
 
-+ (instancetype)wta_colorNamed:(NSString *)colorName
++ (nullable instancetype)wta_colorNamed:(NSString *)colorName
 {
     return [[self wta_colors] objectForKey:colorName];
 }
 
-+ (void)wta_setColor:(UIColor *)color forName:(NSString *)colorName
++ (void)wta_setColor:(nullable UIColor *)color forName:(nonnull NSString *)colorName
 {
     NSParameterAssert(colorName);
     if (color == nil)
@@ -247,14 +247,14 @@
     return nil;
 }
 
-- (NSArray *)wta_RGBColorComponents
+- (NSArray<NSString*> *)wta_RGBColorComponents
 {
     NSString *RGBAString = self;
     NSRange range = [RGBAString rangeOfString:@"("];
     range.location ++;
     range.length = [RGBAString rangeOfString:@")"].location - range.location;
     RGBAString = [RGBAString substringWithRange:range];
-    NSArray *components = [RGBAString componentsSeparatedByString:@","];
+    NSArray<NSString*> *components = [RGBAString componentsSeparatedByString:@","];
     if ([components count] == 3)
     {
         components = [components arrayByAddingObject:@"1.0"];

--- a/WTAHelpers/WTAColorImage/UIImage+WTAColorImage.h
+++ b/WTAHelpers/WTAColorImage/UIImage+WTAColorImage.h
@@ -6,6 +6,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIImage (WTAColorImage)
 
 /**
@@ -33,7 +35,7 @@
 + (UIImage *)wta_imageWithSize:(CGSize)size
                backgroundColor:(UIColor *)backgroundColor
                     borderEdge:(UIRectEdge)borderEdge
-                   borderColor:(UIColor *)borderColor
+                   borderColor:(UIColor * __nullable)borderColor
                    borderWidth:(CGFloat)borderWidth;
 
 /**
@@ -47,3 +49,5 @@
 - (UIImage *)wta_desaturatedImage;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTAFrameHelpers/UIView+WTAFrameHelpers.h
+++ b/WTAHelpers/WTAFrameHelpers/UIView+WTAFrameHelpers.h
@@ -25,6 +25,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  WTAFrameHelpers provides convenience methods for view placement and frame information.
  */
@@ -329,3 +331,5 @@
 - (void)wta_setFrameOriginYAboveView:(UIView *)view offset:(CGFloat)offset;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTAFrameHelpers/WTAHelpersDemo-Bridging-Header.h
+++ b/WTAHelpers/WTAFrameHelpers/WTAHelpersDemo-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/WTAHelpers/WTAFunctionalHelpers/NSArray+WTAFunctionalHelpers.h
+++ b/WTAHelpers/WTAFunctionalHelpers/NSArray+WTAFunctionalHelpers.h
@@ -7,43 +7,42 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+@interface NSArray<ObjectType> (WTAFunctionalHelpers)
 
-@interface NSArray (WTAFunctionalHelpers)
+-(NSMutableArray*)wta_mapWithBlock:(__nullable id (^)(ObjectType))block;
 
--(NSMutableArray*)wta_mapWithBlock:(id (^)(id))block;
-
--(void)wta_enumerateWithBlock:(id (^)(id))block;
-
--(id)wta_reduceWithBlock:(id (^)(id memo, id element))block
+-(id)wta_reduceWithBlock:(id (^)(id memo, ObjectType element))block
                     startValue:(id)memo;
 
--(id)wta_reduceRightWithBlock:(id (^)(id memo, id element))block
+-(id)wta_reduceRightWithBlock:(id (^)(id memo, ObjectType element))block
                          startValue:(id)memo;
 
 -(NSMutableArray*)wta_pluckAtKeyPath:(NSString*)keyPath;
 
--(NSArray*)wta_makeUnique;
+-(NSArray<ObjectType>*)wta_makeUnique;
 
--(NSMutableArray*)wta_shuffle;
+-(NSMutableArray<ObjectType>*)wta_shuffle;
 
 -(NSArray*)wta_flatten;
 
--(id)wta_findWithTest:(BOOL (^)(id))test;
+-(__nullable id)wta_findWithTest:(BOOL (^)(ObjectType))test;
 
--(id)wta_findWithMaximumValue:(NSInteger (^)(id))test;
+-(__nullable id)wta_findWithMaximumValue:(NSInteger (^)(ObjectType))test;
 
--(NSMutableArray*)wta_filterWithTest:(BOOL (^)(id))test;
+-(NSMutableArray<ObjectType>*)wta_filterWithTest:(BOOL (^)(ObjectType))test;
 
--(NSMutableArray*)wta_rejectWithTest:(BOOL (^)(id))test;
+-(NSMutableArray<ObjectType>*)wta_rejectWithTest:(BOOL (^)(ObjectType))test;
 
--(BOOL)wta_allPassTest:(BOOL (^)(id))test;
+-(BOOL)wta_allPassTest:(BOOL (^)(ObjectType))test;
 
--(BOOL)wta_anyPassTest:(BOOL (^)(id))test;
+-(BOOL)wta_anyPassTest:(BOOL (^)(ObjectType))test;
 
--(NSDictionary*)wta_groupByKeyFromElement:(id (^)(id))keyFromElement;
+-(NSDictionary*)wta_groupByKeyFromElement:(id (^)(ObjectType))keyFromElement;
 
 -(NSDictionary*)wta_groupByKeyPath:(NSString*)keyPath;
 
-- (NSArray*)wta_arrayByInsertingObject:(id)object atIndex:(NSInteger)index;
+- (NSArray<ObjectType>*)wta_arrayByInsertingObject:(ObjectType)object atIndex:(NSInteger)index;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTAFunctionalHelpers/NSArray+WTAFunctionalHelpers.m
+++ b/WTAHelpers/WTAFunctionalHelpers/NSArray+WTAFunctionalHelpers.m
@@ -23,13 +23,6 @@
     return result;
 }
 
--(void)wta_enumerateWithBlock:(id (^)(id))block
-{
-    for (id obj in self) {
-        block(obj);
-    }
-}
-
 -(id)wta_reduceWithBlock:(id (^)(id memo, id element))block
                     startValue:(id)memo
 {
@@ -128,6 +121,7 @@
     }
     return maxObject;
 }
+
 -(NSMutableArray*)wta_filterWithTest:(BOOL (^)(id))test
 {
     return [self wta_mapWithBlock:^id(id obj) {

--- a/WTAHelpers/WTANibLoading/UIView+WTANibLoading.h
+++ b/WTAHelpers/WTANibLoading/UIView+WTANibLoading.h
@@ -25,6 +25,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  This category adds a method to `UIView` to make nib loading easier.
  */
@@ -51,13 +53,15 @@
  @param nib to load the view from.
  @return The newly instantiated view.
  */
-+ (instancetype)wta_loadInstanceWithNib:(UINib *)nib;
++ (__nullable instancetype)wta_loadInstanceWithNib:(UINib *)nib;
 
 /**
  Instantiates the first occurence of the view's class in the nib. This method loads the nib with the name equal to the view's class.
  
  @return The newly instantiated view.
  */
-+ (instancetype)wta_loadInstanceFromNib;
++ (__nullable instancetype)wta_loadInstanceFromNib;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTAReusableIdentifier/WTAReusableIdentifier.h
+++ b/WTAHelpers/WTAReusableIdentifier/WTAReusableIdentifier.h
@@ -25,6 +25,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  This category adds a method to `UICollectionReusableView` to make reusableIdentifiers easier.
  */
@@ -60,3 +62,5 @@
 + (NSString *)wta_reuseableIdentifier;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WTAHelpers/WTASwiftHelpers/UIControl+ActionBinding.swift
+++ b/WTAHelpers/WTASwiftHelpers/UIControl+ActionBinding.swift
@@ -1,0 +1,65 @@
+//
+//  UIControl+ActionBinding.swift
+//  WTAHelpers
+//
+//  Created by Robert Thompson on 8/19/15.
+//  Copyright © 2015 WillowTree Apps, Inc. All rights reserved.
+//
+
+import UIKit
+
+private class ActionBinding<T: UIControl>
+{
+    weak var control: T?
+    let boundFunction: (T) -> Void
+    let action: UIControlEvents
+    
+    init(control: T, action: UIControlEvents, boundFunction: (T) -> Void)
+    {
+        self.control = control
+        self.boundFunction = boundFunction
+        self.action = action
+        
+        control.addTarget(self, action: "actionHappened:", forControlEvents: action)
+    }
+    
+    dynamic func actionHappened(sender: UIControl)
+    {
+        boundFunction(sender as! T)
+    }
+    
+    deinit {
+        control?.removeTarget(self, action: "actionHappened:", forControlEvents: action)
+    }
+}
+
+private func createBinding<T: UIControl>(control: T, action: UIControlEvents, function: (T) -> Void) -> ActionBinding<T>
+{
+    return ActionBinding<T>(control: control, action: action, boundFunction: function)
+}
+
+public protocol UIControlBindable: AnyObject
+{
+}
+
+public extension UIControlBindable where Self: UIControl
+{
+    private var bindings: [ActionBinding<Self>] {
+        get {
+            let bindings: [ActionBinding<Self>]? = objc_getAssociatedObject(self, &AssociatedKeys.Bindings) as? [ActionBinding<Self>]
+            return bindings ?? []
+        }
+    }
+    
+    public func bindToEvent(event: UIControlEvents, boundFunc: (Self) -> Void) {
+        let binding = createBinding(self, action: event, function: boundFunc)
+        let bindings = self.bindings + [binding]
+        objc_setAssociatedObject(self, &AssociatedKeys.Bindings, bindings, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+}
+
+extension UIControl: UIControlBindable {
+    private struct AssociatedKeys {
+        static var Bindings = "Bindings"
+    }
+}

--- a/WTAHelpers/WTASwiftHelpers/UIControl+ActionBinding.swift
+++ b/WTAHelpers/WTASwiftHelpers/UIControl+ActionBinding.swift
@@ -8,41 +8,77 @@
 
 import UIKit
 
-private class ActionBinding<T: UIControl>
+private class ActionBinding<T: UIControl>: NSObject
 {
-    weak var control: T?
-    let boundFunction: (T) -> Void
-    let action: UIControlEvents
+    private weak var control: T?
+    private let action: (T) -> Void
+    private let event: UIControlEvents
     
-    init(control: T, action: UIControlEvents, boundFunction: (T) -> Void)
+    /**
+    Create a new ActionBinding
+    
+    - parameter control:       The control who's action you wish to bind
+    - parameter event:        The UIControlEvents you want to bind to
+    - parameter action: The closure that will be executed when the above event happens
+    
+    - returns: The ActionBinding object
+    */
+    private init(control: T, event: UIControlEvents, action: (T) -> Void)
     {
         self.control = control
-        self.boundFunction = boundFunction
         self.action = action
+        self.event = event
         
-        control.addTarget(self, action: "actionHappened:", forControlEvents: action)
+        super.init()
+        
+        control.addTarget(self, action: "actionHappened:", forControlEvents: event)
     }
+   
+    /**
+    The method called when the bound action fires
     
-    dynamic func actionHappened(sender: UIControl)
+    - parameter sender: This is sent by the system when the UIControl's action fires.
+    It's defined as a UIControl here and not T because this method must be visible to Objective-C
+    */
+    private dynamic func actionHappened(sender: UIControl)
     {
-        boundFunction(sender as! T)
+        if let control = control
+        {
+            action(control)
+        }
     }
     
     deinit {
-        control?.removeTarget(self, action: "actionHappened:", forControlEvents: action)
+        control?.removeTarget(self, action: "actionHappened:", forControlEvents: event)
     }
 }
 
-private func createBinding<T: UIControl>(control: T, action: UIControlEvents, function: (T) -> Void) -> ActionBinding<T>
+/**
+This factory function is required due to a compiler bug with calling ActionBinding<Self>(…) in 
+the protocol extension.
+
+- parameter control:  The control who's action you wish to bind
+- parameter action:  The UIControlEvents you want to bind to
+- parameter function: The closure that will be executed when the above action happens
+
+- returns: The ActionBinding object
+*/
+private func createBinding<T: UIControl>(control: T, event: UIControlEvents, action: (T) -> Void) -> ActionBinding<T>
 {
-    return ActionBinding<T>(control: control, action: action, boundFunction: function)
+    return ActionBinding<T>(control: control, event: event, action: action)
 }
 
-public protocol UIControlBindable: AnyObject
+/**
+    This protocol specifies the onEvent method, which is actually implemented in the private
+    protocol extension
+*/
+public protocol UIControlActionBindable: NSObjectProtocol
 {
+    func onEvent(event: UIControlEvents, doAction action: Action) -> Void
 }
 
-public extension UIControlBindable where Self: UIControl
+// MARK: - UIControlActionBindable extension
+public extension UIControlActionBindable where Self: UIControl
 {
     private var bindings: [ActionBinding<Self>] {
         get {
@@ -51,15 +87,28 @@ public extension UIControlBindable where Self: UIControl
         }
     }
     
-    public func bindToEvent(event: UIControlEvents, boundFunc: (Self) -> Void) {
-        let binding = createBinding(self, action: event, function: boundFunc)
+    /// A closure which takes a parameter of type whatever this UIControl actually is
+    public typealias Action = Self -> Void
+    
+    /**
+    This method binds the provided closure to this control, fired when the given events occur
+    
+    - parameter event:     A mask of events you want to bind an action to
+    - parameter doAction: The closure that fires when the above events occur
+    */
+    public func onEvent(event: UIControlEvents, doAction action: Action) {
+        let binding = createBinding(self, event: event, action: action)
         let bindings = self.bindings + [binding]
         objc_setAssociatedObject(self, &AssociatedKeys.Bindings, bindings, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
 }
 
-extension UIControl: UIControlBindable {
-    private struct AssociatedKeys {
-        static var Bindings = "Bindings"
-    }
+/**
+    Provides the static pointer that objc_setAssociatedObject and objc_getAssociatedObject need for a key.
+*/
+private struct AssociatedKeys {
+    static var Bindings = "Bindings"
 }
+
+extension UIControl: UIControlActionBindable { }
+

--- a/WTAHelpers/WTASwiftHelpers/UIControl+ActionBinding.swift
+++ b/WTAHelpers/WTASwiftHelpers/UIControl+ActionBinding.swift
@@ -11,7 +11,7 @@ import UIKit
 private class ActionBinding<T: UIControl>: NSObject
 {
     private weak var control: T?
-    private let action: (T) -> Void
+    private let action: T -> Void
     private let event: UIControlEvents
     
     /**
@@ -23,7 +23,7 @@ private class ActionBinding<T: UIControl>: NSObject
     
     - returns: The ActionBinding object
     */
-    private init(control: T, event: UIControlEvents, action: (T) -> Void)
+    private init(control: T, event: UIControlEvents, action: T -> Void)
     {
         self.control = control
         self.action = action
@@ -31,7 +31,7 @@ private class ActionBinding<T: UIControl>: NSObject
         
         super.init()
         
-        control.addTarget(self, action: "actionHappened:", forControlEvents: event)
+        control.addTarget(self, action: "eventHappened:", forControlEvents: event)
     }
    
     /**
@@ -40,7 +40,7 @@ private class ActionBinding<T: UIControl>: NSObject
     - parameter sender: This is sent by the system when the UIControl's action fires.
     It's defined as a UIControl here and not T because this method must be visible to Objective-C
     */
-    private dynamic func actionHappened(sender: UIControl)
+    private dynamic func eventHappened(sender: UIControl)
     {
         if let control = control
         {
@@ -49,7 +49,7 @@ private class ActionBinding<T: UIControl>: NSObject
     }
     
     deinit {
-        control?.removeTarget(self, action: "actionHappened:", forControlEvents: event)
+        control?.removeTarget(self, action: "eventHappened:", forControlEvents: event)
     }
 }
 
@@ -63,7 +63,7 @@ the protocol extension.
 
 - returns: The ActionBinding object
 */
-private func createBinding<T: UIControl>(control: T, event: UIControlEvents, action: (T) -> Void) -> ActionBinding<T>
+private func createBinding<T: UIControl>(control: T, event: UIControlEvents, action: T -> Void) -> ActionBinding<T>
 {
     return ActionBinding<T>(control: control, event: event, action: action)
 }


### PR DESCRIPTION
The first Swift-specific helper is one that lets you bind a closure to any event that can be fired by a UIControl. The neat part is type information is retained, so inside the closure you know the sender was a textField or a UIButton, or whatever it happens to be, including custom controls.